### PR TITLE
Aaron PR to main

### DIFF
--- a/apps/aws-load-balancer-controller-app.yaml
+++ b/apps/aws-load-balancer-controller-app.yaml
@@ -15,10 +15,14 @@ spec:
   source:
     repoURL: https://aws.github.io/eks-charts
     targetRevision: 1.13.2
-    chart: aws-load-balancer-controller
     helm:
-      valueFiles:
-        - values.yaml
+      values: |
+        clusterName: ce-grp-1-eks
+        region: us-east-1
+        vpcId: vpc-0ce13075f23d1c50d
+        serviceAccount:
+          create: false
+          name: aws-load-balancer-controller
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system

--- a/aws-load-balancer-controller-app/values.yaml
+++ b/aws-load-balancer-controller-app/values.yaml
@@ -7,3 +7,6 @@ vpcId: vpc-0ce13075f23d1c50d
 serviceAccount:
   create: false
   name: aws-load-balancer-controller
+
+# Argo CD cannot use valueFiles: when the repoURL is a Helm repo like https://aws.github.io/eks-charts.
+# So your aws-load-balancer-controller-app.yaml must include inline Helm values like this:


### PR DESCRIPTION
# Argo CD cannot use valueFiles: when the repoURL is a Helm repo like https://aws.github.io/eks-charts.
# So your aws-load-balancer-controller-app.yaml must include inline Helm values like this: